### PR TITLE
Fix issue #7, admissible heuristics now run optimal.

### DIFF
--- a/a-star.pl
+++ b/a-star.pl
@@ -47,13 +47,14 @@ a_star(PQ, V, Solution, C):-
 next_node(SR, Q, V, E, NewSR):-
 		state_record(S, _, _, D, SR),
 		step(S, A, NewS),
-		state_record(NewS, _, _, _, Temp),
-		\+ my_ord_member(NewS, V),
-		heap_to_list(Q, PQL),
-		\+ member(Temp, PQL),
+%		state_record(NewS, _, _, _, Temp),
+%		\+ my_ord_member(NewS, V),
+%		heap_to_list(Q, PQL),
+%		\+ member(Temp, PQL),
 		h(S, H),
 		E is H+D,
 		ND is D+1,
+		\+ weighted_member(NewS, V, ND),
 		state_record(NewS, S, A, ND, NewSR).
 
 %add_list_to_heap(+OldHeap, List, NewHeap)
@@ -68,3 +69,28 @@ my_ord_member(S, [SR|_]):-
 		!.
 my_ord_member(S, [_|T]):-
 		my_ord_member(S, T).
+
+% Checks if S is in the list V with a higher cost.
+% If S's state is in V but with a higher cost (deep), then it fails (a-star re-visits).
+% This test is needed for non-monotonic heuristic if you want an optimal solution,
+% but if not, it runs faster with my_ord_member. 
+% weighted_member(+State, +Visited, +DeepValue)	
+weighted_member(S, [SR|_], K) :-
+		state_record(S2, _, _, D2, SR),
+		repeating(S, S2),
+		K >= D2,
+		!.
+weighted_member(S, [_|T], K) :-
+		weighted_member(S, T, K).
+
+% Pops from heap, until an unvisited node is found.
+% my_pop(OldHeap, Visited, Datum, NewHeap)
+my_pop(OH, K, SR, NH, V) :-
+		get_from_heap(OH, K, SR, NH),
+		SR = [S, _, _, D], 
+%		\+ my_ord_member(S, V), % This is faster
+		\+ weighted_member(S, V, D), % This is essential for non-monotone heuristics
+		!.
+my_pop(OH, K, D, NH, V) :-
+		get_from_heap(OH, _, _, CurrentHeap), 
+		my_pop(CurrentHeap, K, D, NH, V).

--- a/a-star.pl
+++ b/a-star.pl
@@ -23,16 +23,19 @@ a_star(S, A, C):-
 a_star(PQ, _, 'NO SOLUTION', _):-
 		empty_heap(PQ),!.
 a_star(PQ, V, Solution, C):-
-		get_from_heap(PQ, C, SR, _),
+		my_pop(PQ, C, SR, _, V),
+%		get_from_heap(PQ, C, SR, _),
 		state_record(S, _, _, _, SR),
 		is_goal(S),
 %		write('FOUND SOLUTION'),nl,
 %		state_record(S, _, _, D, SR), write(C-D), write('   '),write(S),nl,
 %		writel(V),nl,halt,
-		solution(SR, V, Solution).
+		solution2(SR, V, Solution).
+%		solution(SR, V, Solution).
 
 a_star(PQ, V, Solution, C):-
-		get_from_heap(PQ, _K, SR, RPQ),
+		my_pop(PQ, _K, SR, RPQ, V),
+%		get_from_heap(PQ, _K, SR, RPQ),	
 		ord_add_element(V, SR, NV),
 		(bagof(K-NS, next_node(SR, PQ, NV, K, NS), NextNodes) ; NextNodes=[]),
 %		state_record(S, _, _, D, SR), write(_K-D), write('   '),write(S),length(NextNodes, L), write(L),nl,
@@ -44,7 +47,7 @@ a_star(PQ, V, Solution, C):-
 		a_star(NPQ, NV, Solution, C).
 
 %next_node(+StateRecord, +Queue, +Visited, -EstimateDeep, -NewStateRecord)
-next_node(SR, Q, V, E, NewSR):-
+next_node(SR, _Q, V, E, NewSR):-
 		state_record(S, _, _, D, SR),
 		step(S, A, NewS),
 %		state_record(NewS, _, _, _, Temp),

--- a/common2.pl
+++ b/common2.pl
@@ -14,3 +14,124 @@ get_solution(DomainFile, ProblemFile, L) :-
                 time_out(solve(D, P, S), 3000, _Result), % time limit for a planner
                 length(S, L),
                 !.
+
+% This added predicate checks for the minimal node, so that an optimal
+% solution will always be given.
+% This predicate is mandatory in exchange for "solution" when nodes have
+% been revisited (for example with a non-monotone heuristic for a-star)
+% if you want an optimal solution.
+% solution2(+StateRecord, +Visited, -ListOfActions) 
+solution2(SR, V, L):-
+                solution2(SR, V, [], L).
+solution2(SR, _, L, L):-
+                state_record(_, nil, nil, _, SR), !.
+solution2(SR, V, R, L):-
+                state_record(_, PS, AD, _, SR),
+                findall(Prev, (state_record(PS, _, _, _, Prev), member(Prev, V)), Trail),
+                choose_min_prev(Trail, Min), 
+                solution2(Min, V, [AD|R], L).
+
+% When there are multiple nodes to backtrack to, this chooses the one with lowest depth
+% choose_min_prev(+List, -Minimum)
+choose_min_prev([H|T], Min) :- choose_min_prev(T, H, Min).
+
+choose_min_prev([], Min, Min) :- !.
+choose_min_prev([H|T], Current, Min) :-
+                state_record(_, _, _, D_Current, Current),
+                state_record(_, _, _, D_New, H),
+                D_New < D_Current,
+                choose_min_prev(T, H, Min).
+choose_min_prev([_|T], Current, Min) :-
+                choose_min_prev(T, Current, Min).
+
+% The following are a number of printing predicates. These are really handy 
+% for debugging. 
+
+% Prints Queue (List of nodes)
+print_queue(H) :- 
+                print('Printing Queue: '), nl, my_print_queue(H, 0).
+
+my_print_queue([], _) :- nl, !.
+my_print_queue([H|T], Count) :-
+%                print('    '),
+                H = K-State,
+                print_node(State, Count, K), nl,
+                Count1 is Count + 1,
+                my_print_queue(T, Count1), !.
+my_print_queue(_, _) :- print('Queue not on right format'), nl.
+
+% Prints the information of a node in the heap
+print_node(N) :- print('Printing Node :'), nl, print_node(N, 0, 'Unknown').
+
+%print_node([], _, _) :- !.                    
+print_node([S, PS, A, D], Counter, K) :-
+                print('    '), print('Number in list : '), print(Counter), nl,
+                print('    '), print('State: '), print_state(S), nl,
+                print('    '), print('Previous State: '), print_state(PS), nl,
+                print('    '), print('Action: '), print(A), nl,
+                print('    '), print('Deep: '), print(D), nl,
+                print('    '), print('A-star value: '), print(K), nl, !.
+print_node(_, _, _) :-
+                print('Node on wrong format'), nl.
+
+% Prints a PDDL state, with the information I am intersted in (non-static predicates). 
+print_state([]) :- !.
+print_state([H|T]) :-
+                print_pred(H),
+                print_state(T).
+
+% Prints the predicates from the PDDL file im interested in, the non-static ones
+% This is currently specifically designed for the hanoi problem, but it can be
+% easily modified to work with other predicates. Just change the first predicates
+% to the predicates you do not want printed, and the predicates in the rules to the
+% ones you want printed out. 
+print_pred(smaller(_, _)).
+print_pred(clear(_)).
+print_pred(X) :- 
+                \+ X = smaller(_, _),
+%                \+ X = on(_, _),
+                \+ X = clear(_),
+                print('    '), 
+                print(X).
+
+% Prints a list of nodes, with help from print_node and print_state
+print_list_of_nodes(L) :- print_list_of_nodes(L, 0). 
+
+print_list_of_nodes([], _) :- !.
+print_list_of_nodes([H|T], Counter) :- 
+                print_node(H, Counter, 'Unknown'), Counter1 is Counter + 1, print_list_of_nodes(T, Counter1).
+    
+% Printing list in a nice way for problems and domains
+print_list([]) :- !.
+print_list([H|T]) :- print('        '), print(H), nl, print_list(T).
+
+% Prints the domain with all the variables, some being not so interesting.
+my_print(domain(N, R, T, C, P, F, C, S)) :- 
+                print('N (name): '), print(N), nl,
+                print('R (requirements): '), print(R), nl,
+                print('T (types): '), print(T), nl,
+                print('C (constants): '), print(C), nl,
+                print('P (predicates): '), print(P), nl,
+                print('F (functions): '), print(F), nl,
+                print('C (constraints): '), print(C), nl,
+                print('S (structure): '), print(S), nl.
+
+% Printing domain in a nice way, only the variables I am interested in
+print_domain(domain(N, _, _, _, P, _, _, S)):-
+                print('N (name): '), print(N), nl,
+                print('P (predicates): '), print(P), nl,
+                print('S (structure): '), nl, print_list(S), nl.
+
+% Printing problem in a nice way
+print_problem(problem(Name, Domain, _R, OD, I, G, _Unknown, _MS, _LS)) :-
+                print('Name: '), print(Name), nl,
+                print('Domain: '), print(Domain), nl,
+%                print('R: '), print(R), nl,
+                print('Object Declaration: '), print(OD), nl,
+                print('Init: '), print(I), nl,
+                print('Goal: '), print(G), nl.
+%                print('Unkown: '), print(Unknown), nl,
+%                print('MS: '), print(MS), nl,
+%                print('LS: '), print(LS), nl.
+
+

--- a/testing.pl
+++ b/testing.pl
@@ -23,8 +23,9 @@
 :- use_module(library(plunit)).
 
 :-[readFile, parseProblem, parseDomain, common, common2].
-:- ['a-star', forward, h_add].
+%:- ['a-star', forward, h_add].
 %:- ['a-star', forward, h_0].
+:- ['a-star', forward, h_max].
 %:- ['a-star', forward, h_diff].
 
 :- begin_tests(test_hanoi).


### PR DESCRIPTION
This merge fix the bug discussed in issue #7, so the admissible heuristics now run optimal (h_0 and h_max are admissible, h_diff are admissible in all of the implemented problems, h_add is not admissible, and h_manhattan is admissible only for the sliding problems). 

The fix implements three new predicates, but for monotone heuristics only one is needed. In ```a-star.pl```, ```my_pop``` replaces ```get_from_heap```  and ```weighted_member``` replaces ```my_ord_member```. In ```common2.pl```, ```solution2``` replaces ```solution``` in ```common.pl```. Note that for monotone heuristics, only ```my_pop``` is needed, and the algorithm will run faster with only this changed.

- ```my_pop``` pops nodes of heap until a not-visited node is found (or else it keeps popping). 
- ```weighted_member``` allows repetition of nodes if they are visited in a lower depth. This mean that they will not count as "visited", if the newer visit does it in a shorter path (this might happen in non-monotone heuristics, but you are guaranteed to not have it happen for monotones).
- ```solution2``` backtracks so that if there are multiple paths, the shortest path will be chosen. Monotone heuristics will only return one path. 

```common.pl``` and ```common2.pl``` might be merged, but I left them separate now so that it is easier to read the changes. 
